### PR TITLE
Fix banner error

### DIFF
--- a/sshscan.py
+++ b/sshscan.py
@@ -11,7 +11,7 @@ from optparse import OptionParser, OptionGroup
 
 
 def banner():
-    banner = """
+    banner = r"""
       _____ _____ _    _ _____
      /  ___/  ___| | | /  ___|
      \ `--.\ `--.| |_| \ `--.  ___ __ _ _ __


### PR DESCRIPTION
This fixes the following error on newer Python 3 versions:
```
sshscan.py:14: SyntaxWarning: invalid escape sequence '\ '
```